### PR TITLE
bug fix: distanceFunctions.R

### DIFF
--- a/R/distanceFunctions.R
+++ b/R/distanceFunctions.R
@@ -118,7 +118,7 @@ Mahalanobis <- function(dfv, column.nums=1:ncol(dfv), subset=1:nrow(dfv), S=NULL
   for (i in 1:ncol(df.vars)) {
     diff[,i] <- diff[,i] - M[i]
   }
-  distance <- sqrt( rowSums((diff %*% solve(S))*diff) )
+  distance <- Mod(sqrt(as.complex(rowSums((diff %*% solve(S)) * diff, na.rm = TRUE))))
 
   return(distance)
 } # end Mahalanobis


### PR DESCRIPTION
When NA values are present, the function currently doesn't work. Not because of the covariance matrix, but because `rowSums` didn't have `na.rm = TRUE` and the `sqrt` function couldn't compute negative values. The fix is to use complex number and included in this pull request.